### PR TITLE
fix error that cannot proxy request after parsing body

### DIFF
--- a/src/routes/v2/genai.route.js
+++ b/src/routes/v2/genai.route.js
@@ -1,4 +1,4 @@
-const { createProxyMiddleware } = require('http-proxy-middleware');
+const { createProxyMiddleware, fixRequestBody } = require('http-proxy-middleware');
 const config = require('../../config/config');
 const { proxyHandler } = require('../../config/proxyHandler');
 const { checkPermission } = require('../../middlewares/permission');
@@ -12,6 +12,9 @@ const proxyMiddleware = config.services.genAI.url
   ? createProxyMiddleware({
       target: config.services.genAI.url,
       changeOrigin: true,
+      on: {
+        proxyReq: fixRequestBody,
+      },
     })
   : null;
 

--- a/src/routes/v2/homologation.route.js
+++ b/src/routes/v2/homologation.route.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const config = require('../../config/config');
 const auth = require('../../middlewares/auth');
-const { createProxyMiddleware } = require('http-proxy-middleware');
+const { createProxyMiddleware, fixRequestBody } = require('http-proxy-middleware');
 const { proxyHandler } = require('../../config/proxyHandler');
 
 const router = express.Router();
@@ -16,6 +16,9 @@ const proxyMiddleware = config.services.homologation.url
   ? createProxyMiddleware({
       target: config.services.homologation.url,
       changeOrigin: true,
+      on: {
+        proxyReq: fixRequestBody,
+      },
     })
   : null;
 


### PR DESCRIPTION
This fixes #18 
add fixRequestBody function from http-proxy-middleware to fix error that cannot proxy request after parsing body