### PR TITLE
fix: remove some headers to prevent proxy auth error

### DIFF
--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -27,8 +27,15 @@ const auth =
       let user;
       // If auth service url is provided, use it to authenticate the user
       if (config.services.auth.url) {
+        const forwardHeaders = { ...req.headers };
+        delete forwardHeaders['content-length'];
+        delete forwardHeaders['keep-alive'];
+        delete forwardHeaders['proxy-connection'];
+        delete forwardHeaders['transfer-encoding'];
+        delete forwardHeaders['upgrade'];
+        delete forwardHeaders['trailer'];
         const response = await axios.post(config.services.auth.url, req.body, {
-          headers: req.headers,
+          headers: forwardHeaders,
         });
         user = response?.data?.user;
         user = sanitizeUser(user);


### PR DESCRIPTION
This fixes #20 

Previously, when AUTH_URL is specified, a POST request using axios will be sent to the auth service, including the whole headers from client. This cause the request hanging later when proxy to other services.

Removing these following headers from axios request solves the problem:
- content-length
- keep-alive
- proxy-connection
- transfer-encoding
- upgrade
- trailer