### PR TITLE
fix: change type of schemaDefinition and data to string

### DIFF
--- a/src/controllers/instance.controller.js
+++ b/src/controllers/instance.controller.js
@@ -3,22 +3,25 @@ const pick = require('../utils/pick');
 const ApiError = require('../utils/ApiError');
 const catchAsync = require('../utils/catchAsync');
 const { instanceService } = require('../services');
+const ParsedJsonPropertyMongooseDecorator = require('../decorators/ParsedJsonPropertyMongooseDecorator');
+const ParsedJsonPropertyMongooseListDecorator = require('../decorators/ParsedJsonPropertyMongooseListDecorator');
 
 const createInstance = catchAsync(async (req, res) => {
   const instance = await instanceService.createInstance(req.body, req.user.id);
-  res.status(httpStatus.CREATED).send(instance);
+  res.status(httpStatus.CREATED).send(new ParsedJsonPropertyMongooseDecorator(instance, 'data').getParsedJsonPropertyData());
 });
 
 const getInstances = catchAsync(async (req, res) => {
   const filter = pick(req.query, ['schema']); // Filter by schema ObjectId
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
   const result = await instanceService.queryInstances(filter, options);
+  result.results = new ParsedJsonPropertyMongooseListDecorator(result.results, 'data').getParsedJsonPropertyDataList();
   res.send(result);
 });
 
 const getInstance = catchAsync(async (req, res) => {
   const instance = await instanceService.getInstanceById(req.params.instanceId);
-  res.send(instance);
+  res.send(new ParsedJsonPropertyMongooseDecorator(instance, 'data').getParsedJsonPropertyData());
 });
 
 const updateInstance = catchAsync(async (req, res) => {

--- a/src/controllers/schema.controller.js
+++ b/src/controllers/schema.controller.js
@@ -3,10 +3,14 @@ const pick = require('../utils/pick');
 const catchAsync = require('../utils/catchAsync');
 const { schemaService } = require('../services');
 const ApiError = require('../utils/ApiError');
+const ParsedJsonPropertyMongooseDecorator = require('../decorators/ParsedJsonPropertyMongooseDecorator');
+const ParsedJsonPropertyMongooseListDecorator = require('../decorators/ParsedJsonPropertyMongooseListDecorator');
 
 const createSchema = catchAsync(async (req, res) => {
   const schema = await schemaService.createSchema(req.body, req.user.id);
-  res.status(httpStatus.CREATED).send(schema);
+  res
+    .status(httpStatus.CREATED)
+    .send(new ParsedJsonPropertyMongooseDecorator(schema, 'schema_definition').getParsedJsonPropertyData());
 });
 
 const getSchemas = catchAsync(async (req, res) => {
@@ -14,12 +18,16 @@ const getSchemas = catchAsync(async (req, res) => {
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
   options.populate = ['created_by', 'name'];
   const result = await schemaService.querySchemas(filter, options);
+  result.results = new ParsedJsonPropertyMongooseListDecorator(
+    result.results,
+    'schema_definition'
+  ).getParsedJsonPropertyDataList();
   res.send(result);
 });
 
 const getSchema = catchAsync(async (req, res) => {
   const schema = await schemaService.getSchemaById(req.params.schemaId);
-  res.send(schema);
+  res.send(new ParsedJsonPropertyMongooseDecorator(schema, 'schema_definition').getParsedJsonPropertyData());
 });
 
 const updateSchema = catchAsync(async (req, res) => {

--- a/src/decorators/ParsedJsonPropertyMongooseDecorator.js
+++ b/src/decorators/ParsedJsonPropertyMongooseDecorator.js
@@ -12,6 +12,12 @@ class ParsedJsonPropertyMongooseDecorator {
       throw new Error('Error while parsing JSON data: Invalid data format. Data should be object.');
     }
 
+    if (!this.data._doc) {
+      throw new Error(
+        'Error while parsing JSON data: Data is not Mongoose Document. _doc property is not found in the data object.'
+      );
+    }
+
     if (!this.field || typeof this.field !== 'string') {
       throw new Error('Error while parsing JSON data: Field name is not provided or not a string.');
     }

--- a/src/decorators/ParsedJsonPropertyMongooseDecorator.js
+++ b/src/decorators/ParsedJsonPropertyMongooseDecorator.js
@@ -1,0 +1,36 @@
+// This parse JSON property data from a given object. Return the same object but with the specified field parsed.
+class ParsedJsonPropertyMongooseDecorator {
+  /**
+   *
+   * @param {*} data
+   * @param {*} field
+   */
+  constructor(data, field) {
+    this.data = data;
+    this.field = field;
+    if (!this.data || typeof this.data !== 'object') {
+      throw new Error('Error while parsing JSON data: Invalid data format. Data should be object.');
+    }
+
+    if (!this.field || typeof this.field !== 'string') {
+      throw new Error('Error while parsing JSON data: Field name is not provided or not a string.');
+    }
+  }
+
+  getParsedJsonPropertyData() {
+    const fieldData = this.data[this.field];
+    if (!fieldData || typeof fieldData !== 'string') {
+      throw new Error(`Error while parsing JSON data: Field "${this.field}" is not string.`);
+    }
+
+    try {
+      let parsedFieldData = JSON.parse(fieldData);
+      this.data._doc[this.field] = parsedFieldData;
+      return this.data;
+    } catch (error) {
+      throw new Error(`Error while parsing JSON data: ${error.message}`);
+    }
+  }
+}
+
+module.exports = ParsedJsonPropertyMongooseDecorator;

--- a/src/decorators/ParsedJsonPropertyMongooseListDecorator.js
+++ b/src/decorators/ParsedJsonPropertyMongooseListDecorator.js
@@ -1,0 +1,28 @@
+const ParsedJsonPropertyMongooseDecorator = require('./ParsedJsonPropertyMongooseDecorator');
+
+// This parse JSON property data from a given object. Return the same object but with the specified field parsed.
+class ParsedJsonPropertyDataListDecorator {
+  constructor(dataList, field) {
+    this.dataList = dataList;
+    this.field = field;
+    if (!this.dataList || !Array.isArray(this.dataList)) {
+      throw new Error('Error while parsing JSON data list: Invalid data list format. Data should be an array.');
+    }
+
+    if (!this.field || typeof this.field !== 'string') {
+      throw new Error('Error while parsing JSON data: Field name is not provided or not a string.');
+    }
+  }
+
+  getParsedJsonPropertyDataList() {
+    return this.dataList.map((data, index) => {
+      try {
+        return new ParsedJsonPropertyMongooseDecorator(data, this.field).getParsedJsonPropertyData();
+      } catch (error) {
+        throw new Error(`Error while parsing JSON data from list with index ${index}: ${error.message}`);
+      }
+    });
+  }
+}
+
+module.exports = ParsedJsonPropertyDataListDecorator;

--- a/src/models/instance.model.js
+++ b/src/models/instance.model.js
@@ -19,10 +19,8 @@ const instanceSchema = new mongoose.Schema(
     },
     // The actual data/object payload
     data: {
-      type: mongoose.SchemaTypes.Mixed,
+      type: String,
       required: true,
-      // Validation against the referenced schemaDefinition would typically happen
-      // in the service layer before saving, not directly in the Mongoose schema.
     },
     created_by: {
       type: mongoose.SchemaTypes.ObjectId,

--- a/src/models/schema.model.js
+++ b/src/models/schema.model.js
@@ -16,7 +16,7 @@ const schemaSchema = new mongoose.Schema(
       trim: true,
     },
     schema_definition: {
-      type: mongoose.SchemaTypes.Mixed,
+      type: String,
       required: true,
     },
     created_by: {

--- a/src/services/schema.service.js
+++ b/src/services/schema.service.js
@@ -6,12 +6,13 @@ const ajv = new Ajv();
 
 /**
  *
- * @param {Object} schemaDefinition
+ * @param {string} schemaDefinition
  */
 const validateSchemaDefinition = async (schemaDefinition) => {
   try {
-    const validate = ajv.compile(schemaDefinition);
-    validate(schemaDefinition);
+    const schema = JSON.parse(schemaDefinition);
+    const validate = ajv.compile(schema);
+    validate(schema);
   } catch (error) {
     if (error instanceof Ajv.ValidationError) {
       throw new ApiError(httpStatus.BAD_REQUEST, `Schema validation error: ${error.message}`);

--- a/src/validations/instance.validation.js
+++ b/src/validations/instance.validation.js
@@ -4,7 +4,7 @@ const { objectId } = require('./custom.validation');
 const createInstance = {
   body: Joi.object().keys({
     schema: Joi.string().custom(objectId).required(),
-    data: Joi.object(),
+    data: Joi.string().required(),
     name: Joi.string().required(),
   }),
 };
@@ -30,7 +30,7 @@ const updateInstance = {
   }),
   body: Joi.object()
     .keys({
-      data: Joi.object(),
+      data: Joi.string(),
       name: Joi.string(),
     })
     .min(1),

--- a/src/validations/schema.validation.js
+++ b/src/validations/schema.validation.js
@@ -5,7 +5,7 @@ const createSchema = {
   body: Joi.object().keys({
     name: Joi.string().required().trim(),
     description: Joi.string().trim().allow(''),
-    schema_definition: Joi.object().required(),
+    schema_definition: Joi.string().required(),
   }),
 };
 
@@ -33,7 +33,7 @@ const updateSchema = {
     .keys({
       name: Joi.string().trim(),
       description: Joi.string().trim().allow(''),
-      schema_definition: Joi.object(),
+      schema_definition: Joi.string(),
     })
     .min(1), // Require at least one field to update
 };


### PR DESCRIPTION
This fixes #31 

Changes detail:
- Modify Inventory Schema: change type of schema_definition from Mixed to String
- Modify Inventory Instance: change type of data from Mixed to String
- Create decorator to automatically parse the JSON string data of Inventory Schema and Instance before sending to client